### PR TITLE
Reworked the layout of the campaigns

### DIFF
--- a/CampaignBrowser/Base.lproj/Main.storyboard
+++ b/CampaignBrowser/Base.lproj/Main.storyboard
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,7 +12,7 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="CampaignListingViewController" customModule="CampaignBrowser" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="MPh-hb-8E4" customClass="CampaignListingView" customModule="CampaignBrowser" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="KMS-9b-u14">
@@ -26,24 +23,27 @@
                         </collectionViewFlowLayout>
                         <cells>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="campaignCell" id="Kec-Ca-5D8" customClass="CampaignCell" customModule="CampaignBrowser" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="283"/>
+                                <rect key="frame" x="20.666666666666668" y="0.0" width="387" height="405"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="283"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="387" height="405"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="h3t-mf-lUQ">
-                                            <rect key="frame" x="8" y="8" width="359" height="267"/>
+                                            <rect key="frame" x="8" y="8" width="371" height="278.33333333333331"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" secondItem="h3t-mf-lUQ" secondAttribute="height" multiplier="4:3" id="ece-q7-FaY"/>
+                                            </constraints>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YiC-pw-PH8" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
-                                            <rect key="frame" x="8" y="202.5" width="60.5" height="36.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YiC-pw-PH8" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="286.33333333333331" width="379" height="20.333333333333314"/>
                                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                             <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iKV-MD-vzF" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
-                                            <rect key="frame" x="8" y="239" width="359" height="28"/>
+                                            <rect key="frame" x="0.0" y="314.66666666666669" width="379" height="12"/>
                                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                             <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="8"/>
                                             <fontDescription key="fontDescription" name="HoeflerText-Regular" family="Hoefler Text" pointSize="12"/>
@@ -53,17 +53,17 @@
                                     </subviews>
                                 </view>
                                 <constraints>
-                                    <constraint firstAttribute="trailingMargin" secondItem="h3t-mf-lUQ" secondAttribute="trailing" id="0Qv-Ly-s5x"/>
-                                    <constraint firstAttribute="trailingMargin" secondItem="iKV-MD-vzF" secondAttribute="trailing" id="4FB-dA-Inc"/>
-                                    <constraint firstItem="iKV-MD-vzF" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" id="760-sQ-xsE"/>
-                                    <constraint firstAttribute="bottomMargin" secondItem="iKV-MD-vzF" secondAttribute="bottom" constant="8" id="AgS-3w-y75"/>
-                                    <constraint firstItem="YiC-pw-PH8" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" id="PgD-gW-tZP"/>
-                                    <constraint firstItem="iKV-MD-vzF" firstAttribute="top" secondItem="YiC-pw-PH8" secondAttribute="bottom" id="QqG-b8-yhQ"/>
-                                    <constraint firstItem="h3t-mf-lUQ" firstAttribute="top" secondItem="Kec-Ca-5D8" secondAttribute="topMargin" id="bUW-eS-iVs"/>
-                                    <constraint firstAttribute="bottomMargin" secondItem="h3t-mf-lUQ" secondAttribute="bottom" id="uaV-3P-jj4"/>
-                                    <constraint firstItem="h3t-mf-lUQ" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" id="wC4-Bv-2Cj"/>
+                                    <constraint firstAttribute="trailingMargin" secondItem="YiC-pw-PH8" secondAttribute="trailing" id="Ahe-qD-fzI"/>
+                                    <constraint firstItem="h3t-mf-lUQ" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" id="B00-aT-sgx"/>
+                                    <constraint firstItem="YiC-pw-PH8" firstAttribute="top" secondItem="h3t-mf-lUQ" secondAttribute="bottom" id="GgB-af-oMq"/>
+                                    <constraint firstItem="iKV-MD-vzF" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" constant="-8" id="Md8-of-t0a"/>
+                                    <constraint firstItem="h3t-mf-lUQ" firstAttribute="trailing" secondItem="Kec-Ca-5D8" secondAttribute="trailingMargin" id="ORT-Vv-VqI"/>
+                                    <constraint firstItem="iKV-MD-vzF" firstAttribute="top" secondItem="YiC-pw-PH8" secondAttribute="bottom" constant="8" id="egA-Mx-GIL"/>
+                                    <constraint firstItem="YiC-pw-PH8" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" constant="-8.0000000000000089" id="fXp-gZ-G3B"/>
+                                    <constraint firstItem="h3t-mf-lUQ" firstAttribute="top" secondItem="Kec-Ca-5D8" secondAttribute="topMargin" id="pBz-za-cyN"/>
+                                    <constraint firstAttribute="trailingMargin" secondItem="iKV-MD-vzF" secondAttribute="trailing" id="v9R-5e-hPW"/>
                                 </constraints>
-                                <size key="customSize" width="375" height="283"/>
+                                <size key="customSize" width="387" height="405"/>
                                 <connections>
                                     <outlet property="descriptionLabel" destination="iKV-MD-vzF" id="Zvs-Xr-6X8"/>
                                     <outlet property="imageView" destination="h3t-mf-lUQ" id="MKZ-D5-97E"/>
@@ -71,14 +71,14 @@
                                 </connections>
                             </collectionViewCell>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="loadingIndicatorCell" id="SZh-Y0-q4r">
-                                <rect key="frame" x="0.0" y="293" width="375" height="225"/>
+                                <rect key="frame" x="26.666666666666668" y="415" width="375" height="225"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="225"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="o42-h4-YUU">
-                                            <rect key="frame" x="169" y="94.5" width="37" height="37"/>
+                                            <rect key="frame" x="169" y="94" width="37" height="37"/>
                                             <color key="color" red="0.32549019610000002" green="0.68627450980000004" blue="0.59999999999999998" alpha="1" colorSpace="calibratedRGB"/>
                                         </activityIndicatorView>
                                     </subviews>
@@ -102,7 +102,16 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
                 <customObject id="udm-JU-wgA" customClass="LoadingDataSource" customModule="CampaignBrowser" customModuleProvider="target"/>
             </objects>
-            <point key="canvasLocation" x="32.799999999999997" y="37.331334332833585"/>
+            <point key="canvasLocation" x="32.242990654205606" y="36.933045356371494"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="YiC-pw-PH8">
+            <size key="intrinsicContentSize" width="44.666666666666664" height="20.333333333333332"/>
+        </designable>
+        <designable name="iKV-MD-vzF">
+            <size key="intrinsicContentSize" width="28.333333333333332" height="12"/>
+        </designable>
+    </designables>
 </document>
+

--- a/CampaignBrowser/Components/LabelWithPadding.swift
+++ b/CampaignBrowser/Components/LabelWithPadding.swift
@@ -11,11 +11,11 @@ class LabelWithPadding: UILabel {
     @IBInspectable var padding: CGFloat = 8
 
     override func drawText(in rect: CGRect) {
-        super.drawText(in: rect.inset(by: UIEdgeInsets(top: padding, left: padding, bottom: padding, right: padding)))
+        super.drawText(in: rect.inset(by: UIEdgeInsets(top: 0, left: padding, bottom: 0, right: padding))) // Changed the padding on the top and bottom to 0
     }
 
     override var intrinsicContentSize: CGSize {
         let originalSize = super.intrinsicContentSize
-        return CGSize(width: originalSize.width + padding * 2, height: originalSize.height + padding * 2)
+        return CGSize(width: originalSize.width , height: originalSize.height) // Removed the "+ padding * 2"
     }
 }

--- a/CampaignBrowser/Screens/CampaignsListing/CampaignListingView.swift
+++ b/CampaignBrowser/Screens/CampaignsListing/CampaignListingView.swift
@@ -74,15 +74,18 @@ class ListingDataSource: NSObject, UICollectionViewDataSource, UICollectionViewD
             campaignCell.name = campaign.name
             campaignCell.descriptionText = campaign.description
         } else {
-            assertionFailure("The cell should a CampaignCell")
+            assertionFailure("The cell should be a CampaignCell")
         }
         return cell
     }
-
+    
+    //Removing the fixed height and changing to dynamic cell height
+/*
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.frame.size.width, height: 450)
+        return CGSize(width: collectionView.frame.size.width, height: 450) //Changing from the fixed height
     }
+ */
 
 }
 
@@ -109,3 +112,4 @@ class LoadingDataSource: NSObject, UICollectionViewDataSource, UICollectionViewD
         return collectionView.frame.size
     }
 }
+

--- a/CampaignBrowser/Screens/CampaignsListing/CampaingListingViewController.swift
+++ b/CampaignBrowser/Screens/CampaignsListing/CampaingListingViewController.swift
@@ -17,8 +17,13 @@ class CampaignListingViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        //Enabling CollectionView cell to be dynamic
+        let flowLayout = self.typedView.collectionViewLayout as? UICollectionViewFlowLayout
+        flowLayout?.estimatedItemSize = CGSize(width: UIScreen.main.bounds.size.width, height: 450) //Estimated height
 
         assert(typedView != nil)
+        
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/CampaignBrowser/Screens/CampaignsListing/Cells/CampaignCell.swift
+++ b/CampaignBrowser/Screens/CampaignsListing/Cells/CampaignCell.swift
@@ -50,4 +50,22 @@ class CampaignCell: UICollectionViewCell {
         assert(descriptionLabel != nil)
         assert(imageView != nil)
     }
+    
+    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        
+        //Enabling Auto Layout
+        setNeedsLayout()
+        layoutIfNeeded()
+        
+        //Trying to fit contentView to the target size in layoutAttributes
+        let size = contentView.systemLayoutSizeFitting(layoutAttributes.size)
+        
+        //Updating the layoutAttributes with height that was calculated
+        var frame = layoutAttributes.frame
+        frame.size.height = ceil(size.height)   //Rounded up half pixels
+        layoutAttributes.frame = frame
+        
+        return layoutAttributes
+    }
+    
 }


### PR DESCRIPTION
- Used a dynamic height of the cell and made it dependent on the cell's contents.
- The image took the full available width of the screen and dynamically adjusted its height with an aspect ratio of 4:3.
- The text went below the image. There was no space between the title text and the image, because the image already contains whitespace.
- The text had padding of 8 points to the left and to the right.
- There was 8 points spacing between the title text and the description text.
- The title text broke into two lines at most. Every text which was longer than two lines cut after the second line.
- The description text had no length restrictions.