### PR TITLE
paskowski - campaign browser layout

### DIFF
--- a/CampaignBrowser/Base.lproj/Main.storyboard
+++ b/CampaignBrowser/Base.lproj/Main.storyboard
@@ -26,11 +26,11 @@
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="campaignCell" id="Kec-Ca-5D8" customClass="CampaignCell" customModule="CampaignBrowser" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="343"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="343"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="377-ti-orw">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="377-ti-orw" userLabel="CustomContentView">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="343"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="h3t-mf-lUQ">
@@ -39,15 +39,15 @@
                                                         <constraint firstAttribute="width" secondItem="h3t-mf-lUQ" secondAttribute="height" multiplier="4:3" id="STi-9g-KIf"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YiC-pw-PH8" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="281.5" width="375" height="36.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YiC-pw-PH8">
+                                                    <rect key="frame" x="8" y="281.5" width="359" height="20.5"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iKV-MD-vzF" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="318" width="375" height="25"/>
+                                                    <rect key="frame" x="0.0" y="302" width="375" height="28"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                     <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="8"/>
                                                     <fontDescription key="fontDescription" name="HoeflerText-Regular" family="Hoefler Text" pointSize="12"/>
@@ -60,13 +60,13 @@
                                                 <constraint firstItem="YiC-pw-PH8" firstAttribute="top" secondItem="h3t-mf-lUQ" secondAttribute="bottom" id="Jib-Gz-j70"/>
                                                 <constraint firstAttribute="trailing" secondItem="iKV-MD-vzF" secondAttribute="trailing" id="LUK-Cb-g2o"/>
                                                 <constraint firstItem="h3t-mf-lUQ" firstAttribute="leading" secondItem="377-ti-orw" secondAttribute="leading" id="PdU-Ob-3Xs"/>
-                                                <constraint firstItem="YiC-pw-PH8" firstAttribute="leading" secondItem="377-ti-orw" secondAttribute="leading" id="Zzc-uZ-cjR"/>
+                                                <constraint firstItem="YiC-pw-PH8" firstAttribute="leading" secondItem="377-ti-orw" secondAttribute="leading" constant="8" id="Zzc-uZ-cjR"/>
                                                 <constraint firstItem="iKV-MD-vzF" firstAttribute="leading" secondItem="377-ti-orw" secondAttribute="leading" id="b2H-2Z-Ccl"/>
                                                 <constraint firstItem="iKV-MD-vzF" firstAttribute="top" secondItem="YiC-pw-PH8" secondAttribute="bottom" id="iJv-7J-Fd0"/>
-                                                <constraint firstAttribute="trailing" secondItem="YiC-pw-PH8" secondAttribute="trailing" id="krw-PJ-s4I"/>
+                                                <constraint firstAttribute="trailing" secondItem="YiC-pw-PH8" secondAttribute="trailing" constant="8" id="krw-PJ-s4I"/>
                                                 <constraint firstItem="h3t-mf-lUQ" firstAttribute="top" secondItem="377-ti-orw" secondAttribute="top" id="nCp-JJ-LOF"/>
                                                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="iKV-MD-vzF" secondAttribute="bottom" id="s6Q-4d-lgR"/>
-                                                <constraint firstAttribute="width" constant="400" id="sE3-HF-oWT"/>
+                                                <constraint firstAttribute="width" priority="999" constant="400" id="sE3-HF-oWT"/>
                                                 <constraint firstAttribute="trailing" secondItem="h3t-mf-lUQ" secondAttribute="trailing" id="x4C-jz-dfF"/>
                                             </constraints>
                                         </view>
@@ -123,7 +123,7 @@
     </scenes>
     <designables>
         <designable name="YiC-pw-PH8">
-            <size key="intrinsicContentSize" width="60.5" height="36.5"/>
+            <size key="intrinsicContentSize" width="44.5" height="20.5"/>
         </designable>
         <designable name="iKV-MD-vzF">
             <size key="intrinsicContentSize" width="44.5" height="28"/>

--- a/CampaignBrowser/Base.lproj/Main.storyboard
+++ b/CampaignBrowser/Base.lproj/Main.storyboard
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -26,59 +24,77 @@
                         </collectionViewFlowLayout>
                         <cells>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="campaignCell" id="Kec-Ca-5D8" customClass="CampaignCell" customModule="CampaignBrowser" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="283"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="343"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="283"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="343"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="h3t-mf-lUQ">
-                                            <rect key="frame" x="8" y="8" width="359" height="267"/>
-                                        </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YiC-pw-PH8" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
-                                            <rect key="frame" x="8" y="202.5" width="60.5" height="36.5"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                            <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iKV-MD-vzF" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
-                                            <rect key="frame" x="8" y="239" width="359" height="28"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                            <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="8"/>
-                                            <fontDescription key="fontDescription" name="HoeflerText-Regular" family="Hoefler Text" pointSize="12"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="377-ti-orw">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="343"/>
+                                            <subviews>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="h3t-mf-lUQ">
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="281.5"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="h3t-mf-lUQ" secondAttribute="height" multiplier="4:3" id="STi-9g-KIf"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YiC-pw-PH8" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="281.5" width="375" height="36.5"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iKV-MD-vzF" customClass="LabelWithPadding" customModule="CampaignBrowser" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="318" width="375" height="25"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <edgeInsets key="layoutMargins" top="8" left="20" bottom="8" right="8"/>
+                                                    <fontDescription key="fontDescription" name="HoeflerText-Regular" family="Hoefler Text" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            <constraints>
+                                                <constraint firstItem="YiC-pw-PH8" firstAttribute="top" secondItem="h3t-mf-lUQ" secondAttribute="bottom" id="Jib-Gz-j70"/>
+                                                <constraint firstAttribute="trailing" secondItem="iKV-MD-vzF" secondAttribute="trailing" id="LUK-Cb-g2o"/>
+                                                <constraint firstItem="h3t-mf-lUQ" firstAttribute="leading" secondItem="377-ti-orw" secondAttribute="leading" id="PdU-Ob-3Xs"/>
+                                                <constraint firstItem="YiC-pw-PH8" firstAttribute="leading" secondItem="377-ti-orw" secondAttribute="leading" id="Zzc-uZ-cjR"/>
+                                                <constraint firstItem="iKV-MD-vzF" firstAttribute="leading" secondItem="377-ti-orw" secondAttribute="leading" id="b2H-2Z-Ccl"/>
+                                                <constraint firstItem="iKV-MD-vzF" firstAttribute="top" secondItem="YiC-pw-PH8" secondAttribute="bottom" id="iJv-7J-Fd0"/>
+                                                <constraint firstAttribute="trailing" secondItem="YiC-pw-PH8" secondAttribute="trailing" id="krw-PJ-s4I"/>
+                                                <constraint firstItem="h3t-mf-lUQ" firstAttribute="top" secondItem="377-ti-orw" secondAttribute="top" id="nCp-JJ-LOF"/>
+                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="iKV-MD-vzF" secondAttribute="bottom" id="s6Q-4d-lgR"/>
+                                                <constraint firstAttribute="width" constant="400" id="sE3-HF-oWT"/>
+                                                <constraint firstAttribute="trailing" secondItem="h3t-mf-lUQ" secondAttribute="trailing" id="x4C-jz-dfF"/>
+                                            </constraints>
+                                        </view>
                                     </subviews>
                                 </view>
                                 <constraints>
-                                    <constraint firstAttribute="trailingMargin" secondItem="h3t-mf-lUQ" secondAttribute="trailing" id="0Qv-Ly-s5x"/>
-                                    <constraint firstAttribute="trailingMargin" secondItem="iKV-MD-vzF" secondAttribute="trailing" id="4FB-dA-Inc"/>
-                                    <constraint firstItem="iKV-MD-vzF" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" id="760-sQ-xsE"/>
-                                    <constraint firstAttribute="bottomMargin" secondItem="iKV-MD-vzF" secondAttribute="bottom" constant="8" id="AgS-3w-y75"/>
-                                    <constraint firstItem="YiC-pw-PH8" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" id="PgD-gW-tZP"/>
-                                    <constraint firstItem="iKV-MD-vzF" firstAttribute="top" secondItem="YiC-pw-PH8" secondAttribute="bottom" id="QqG-b8-yhQ"/>
-                                    <constraint firstItem="h3t-mf-lUQ" firstAttribute="top" secondItem="Kec-Ca-5D8" secondAttribute="topMargin" id="bUW-eS-iVs"/>
-                                    <constraint firstAttribute="bottomMargin" secondItem="h3t-mf-lUQ" secondAttribute="bottom" id="uaV-3P-jj4"/>
-                                    <constraint firstItem="h3t-mf-lUQ" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leadingMargin" id="wC4-Bv-2Cj"/>
+                                    <constraint firstItem="377-ti-orw" firstAttribute="top" secondItem="Kec-Ca-5D8" secondAttribute="top" id="2zI-aY-ayJ"/>
+                                    <constraint firstAttribute="trailing" secondItem="377-ti-orw" secondAttribute="trailing" id="53C-FJ-4FK"/>
+                                    <constraint firstAttribute="bottom" secondItem="377-ti-orw" secondAttribute="bottom" id="c2N-eb-diU"/>
+                                    <constraint firstItem="377-ti-orw" firstAttribute="leading" secondItem="Kec-Ca-5D8" secondAttribute="leading" id="rNZ-No-J97"/>
                                 </constraints>
-                                <size key="customSize" width="375" height="283"/>
+                                <size key="customSize" width="375" height="343"/>
                                 <connections>
+                                    <outlet property="contentViewWidthConstraint" destination="sE3-HF-oWT" id="jHh-gf-B9x"/>
                                     <outlet property="descriptionLabel" destination="iKV-MD-vzF" id="Zvs-Xr-6X8"/>
                                     <outlet property="imageView" destination="h3t-mf-lUQ" id="MKZ-D5-97E"/>
                                     <outlet property="nameLabel" destination="YiC-pw-PH8" id="zNK-GY-IKJ"/>
                                 </connections>
                             </collectionViewCell>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="loadingIndicatorCell" id="SZh-Y0-q4r">
-                                <rect key="frame" x="0.0" y="293" width="375" height="225"/>
+                                <rect key="frame" x="0.0" y="353" width="375" height="225"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="225"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="o42-h4-YUU">
-                                            <rect key="frame" x="169" y="94.5" width="37" height="37"/>
+                                            <rect key="frame" x="169" y="94" width="37" height="37"/>
                                             <color key="color" red="0.32549019610000002" green="0.68627450980000004" blue="0.59999999999999998" alpha="1" colorSpace="calibratedRGB"/>
                                         </activityIndicatorView>
                                     </subviews>
@@ -105,4 +121,17 @@
             <point key="canvasLocation" x="32.799999999999997" y="37.331334332833585"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="YiC-pw-PH8">
+            <size key="intrinsicContentSize" width="60.5" height="36.5"/>
+        </designable>
+        <designable name="iKV-MD-vzF">
+            <size key="intrinsicContentSize" width="44.5" height="28"/>
+        </designable>
+    </designables>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/CampaignBrowser/Components/LabelWithPadding.swift
+++ b/CampaignBrowser/Components/LabelWithPadding.swift
@@ -18,4 +18,16 @@ class LabelWithPadding: UILabel {
         let originalSize = super.intrinsicContentSize
         return CGSize(width: originalSize.width + padding * 2, height: originalSize.height + padding * 2)
     }
+
+    override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
+        let insets = UIEdgeInsets(
+            top: padding,
+            left: padding,
+            bottom: padding,
+            right: padding
+        )
+        let rect = bounds.inset(by: insets)
+
+        return super.textRect(forBounds: rect, limitedToNumberOfLines: numberOfLines)
+    }
 }

--- a/CampaignBrowser/Screens/CampaignsListing/CampaignListingView.swift
+++ b/CampaignBrowser/Screens/CampaignsListing/CampaignListingView.swift
@@ -19,6 +19,9 @@ class CampaignListingView: UICollectionView {
         let campaignDataSource = ListingDataSource(campaigns: campaigns)
         dataSource = campaignDataSource
         delegate = campaignDataSource
+        if let layout = collectionViewLayout as? UICollectionViewFlowLayout {
+            layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        }
         strongDataSource = campaignDataSource
         reloadData()
     }
@@ -74,14 +77,9 @@ class ListingDataSource: NSObject, UICollectionViewDataSource, UICollectionViewD
             campaignCell.name = campaign.name
             campaignCell.descriptionText = campaign.description
         } else {
-            assertionFailure("The cell should a CampaignCell")
+            assertionFailure("The cell should be a CampaignCell")
         }
         return cell
-    }
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout,
-                        sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.frame.size.width, height: 450)
     }
 
 }

--- a/CampaignBrowser/Screens/CampaignsListing/CampaignListingView.swift
+++ b/CampaignBrowser/Screens/CampaignsListing/CampaignListingView.swift
@@ -76,6 +76,7 @@ class ListingDataSource: NSObject, UICollectionViewDataSource, UICollectionViewD
             campaignCell.moodImage = campaign.moodImage
             campaignCell.name = campaign.name
             campaignCell.descriptionText = campaign.description
+            campaignCell.cellWidth = collectionView.bounds.width
         } else {
             assertionFailure("The cell should be a CampaignCell")
         }

--- a/CampaignBrowser/Screens/CampaignsListing/Cells/CampaignCell.swift
+++ b/CampaignBrowser/Screens/CampaignsListing/Cells/CampaignCell.swift
@@ -18,7 +18,7 @@ class CampaignCell: UICollectionViewCell {
     /** The image view which is used to display the campaign's mood image. */
     @IBOutlet private(set) weak var imageView: UIImageView!
 
-    /** Used to set cell to full width of the screen */
+    /** Used to specify cell's width */
     @IBOutlet private(set) weak var contentViewWidthConstraint: NSLayoutConstraint!
 
     /** The mood image which is displayed as the background. */
@@ -28,7 +28,7 @@ class CampaignCell: UICollectionViewCell {
                 .observeOn(MainScheduler.instance)
                 .subscribe(onNext: { [weak self] image in
                     self?.imageView.image = image
-                    })
+                })
                 .disposed(by: disposeBag)
         }
     }
@@ -40,9 +40,17 @@ class CampaignCell: UICollectionViewCell {
         }
     }
 
+    /** The campaign's description. */
     var descriptionText: String? {
         didSet {
             descriptionLabel?.text = descriptionText
+        }
+    }
+
+    /** Used to set cell's width */
+    var cellWidth: CGFloat? {
+        didSet {
+            contentViewWidthConstraint.constant = cellWidth ?? .zero
         }
     }
 
@@ -52,7 +60,5 @@ class CampaignCell: UICollectionViewCell {
         assert(nameLabel != nil)
         assert(descriptionLabel != nil)
         assert(imageView != nil)
-
-        contentViewWidthConstraint.constant = UIScreen.main.bounds.width
     }
 }

--- a/CampaignBrowser/Screens/CampaignsListing/Cells/CampaignCell.swift
+++ b/CampaignBrowser/Screens/CampaignsListing/Cells/CampaignCell.swift
@@ -18,6 +18,9 @@ class CampaignCell: UICollectionViewCell {
     /** The image view which is used to display the campaign's mood image. */
     @IBOutlet private(set) weak var imageView: UIImageView!
 
+    /** Used to set cell to full width of the screen */
+    @IBOutlet private(set) weak var contentViewWidthConstraint: NSLayoutConstraint!
+
     /** The mood image which is displayed as the background. */
     var moodImage: Observable<UIImage>? {
         didSet {
@@ -49,5 +52,7 @@ class CampaignCell: UICollectionViewCell {
         assert(nameLabel != nil)
         assert(descriptionLabel != nil)
         assert(imageView != nil)
+
+        contentViewWidthConstraint.constant = UIScreen.main.bounds.width
     }
 }


### PR DESCRIPTION
### Summary
In this PR I made the following changes:
    
- Made cell height dependent on the size of its contents.
- Made image span the full width of the screen and adjust its height while keeping the aspect ratio of 4:3
- Moved the text below the image
- Added 8 pt padding to text on the left and right
- Made title text break into two lines at most
- Added support for description text to have an arbitrary length

### Screenshots
<img src="https://user-images.githubusercontent.com/10504217/122975672-e294fc00-d393-11eb-8bdd-74368ba316db.png" width=350>